### PR TITLE
pkp/pkp-lib#3573 Add ID columns for clustering support

### DIFF
--- a/FundingSchemaMigration.inc.php
+++ b/FundingSchemaMigration.inc.php
@@ -32,6 +32,7 @@ class FundingSchemaMigration extends Migration {
 
 			// funder_settings
 			Schema::create('funder_settings', function (Blueprint $table) {
+				$table->bigIncrements('funder_setting_id');
 				$table->bigInteger('funder_id');
 				$table->string('locale', 14)->default('');
 				$table->string('setting_name', 255);
@@ -50,6 +51,7 @@ class FundingSchemaMigration extends Migration {
 
 			// funder_award_settings
 			Schema::create('funder_award_settings', function (Blueprint $table) {
+				$table->bigIncrements('funding_award_setting_id');
 				$table->bigInteger('funder_award_id');
 				$table->string('locale', 14)->default('');
 				$table->string('setting_name', 255);


### PR DESCRIPTION
This improves support for clustering DB deployments by ensuring all columns have primary key IDs. We'll take care of the upgrade migration from 3.3.x to 3.4.x (see https://github.com/pkp/pkp-lib/issues/3573) -- this will take care of it for new installations.