### PR TITLE
feat: Add funding metadata to API response for Submissions and Publications

### DIFF
--- a/FundingPlugin.inc.php
+++ b/FundingPlugin.inc.php
@@ -502,7 +502,7 @@ class FundingPlugin extends GenericPlugin {
 		while ($funder = $funders->next()) {
 			$funderId = $funder->getId();
 			$funderAwards = $funderAwardDao->getFunderAwardNumbersByFunderId($funderId);
-			$funderData[$funderId] = array(
+			$funderData[] = array(
 				'funderName' => $funder->getFunderName(),
 				'funderIdentification' => $funder->getFunderIdentification(),
 				'funderAwards' => array_values($funderAwards)


### PR DESCRIPTION
Hi! Great plugin, works great.

One thing I wanted was the ability to get this funding data from the API when requesting e.g. `/api/v1/submissions/<id>` and `/api/v1/submissions/<id>/publications/<pubId>`.

This pull request adds that functionality, adding the following "funding" field to either API response:

```json
  "funding": [
    {
      "funderName": "Nederlandse Organisatie voor Wetenschappelijk Onderzoek",
      "funderIdentification": "http://dx.doi.org/10.13039/501100003246",
      "funderAwards": [
        "464-18-105"
      ]
    },
    {
      "funderName": "Deutsche Forschungsgemeinschaft",
      "funderIdentification": "http://dx.doi.org/10.13039/501100001659",
      "funderAwards": [
        "HO 4175/7-1"
      ]
    }
  ]
```

I've been using this for awhile myself, decided it'd probably be better to share it!


