### PR TITLE
Re-styles plugin side block

### DIFF
--- a/templates/listFunders.tpl
+++ b/templates/listFunders.tpl
@@ -8,8 +8,8 @@
  * The included template that is hooked into Templates::Article::Details.
  *}
 <div class="item funders">
+	<h2 class="label">{translate key="plugins.generic.funding.fundingData"}</h2>
 	<div class="value">
-		<h3>{translate key="plugins.generic.funding.fundingData"}</h3>
 		<ul>
 			{foreach from=$funderData item=funder}
 				<li>


### PR DESCRIPTION
While using the plugin at SciELO Preprints, we noticed that the plugin block had a different style than the blocks of the other plugins, as you can see in the image below.

![bloco_funding_inconformado](https://github.com/ajnyga/funding/assets/60978081/743cf929-7b2d-4d96-a14d-14d580707a6d)

This PR changes it, making the blocks more cohesive together. Here's an example of use after the changing (in portuguese):

![bloco_funding_conforming](https://github.com/ajnyga/funding/assets/60978081/aae3554a-7526-4e8c-8d30-fe43c04beb72)
