### PR TITLE
Add anchor ID to funding information

### DIFF
--- a/templates/listFunders.tpl
+++ b/templates/listFunders.tpl
@@ -7,7 +7,7 @@
  *
  * The included template that is hooked into Templates::Article::Details.
  *}
-<div class="item funders">
+<div class="item funders" id="funding-data">
 	<h2 class="label">{translate key="plugins.generic.funding.fundingData"}</h2>
 	<div class="value">
 		<ul>


### PR DESCRIPTION
@ajnyga, this PR adds an element ID to the funding data listing. We'd like to use this to link to the specific part of the article landing page that contains the data from the [publication facts label](https://github.com/asmecher/pflPlugin). Let me know if this works for you!