### PR TITLE
Renaming unique key to avoid naming clash on postgres

### DIFF
--- a/FundingSchemaMigration.inc.php
+++ b/FundingSchemaMigration.inc.php
@@ -39,7 +39,7 @@ class FundingSchemaMigration extends Migration {
 				$table->longText('setting_value')->nullable();
 				$table->string('setting_type', 6)->comment('(bool|int|float|string|object)');
 				$table->index(['funder_id'], 'funder_settings_id');
-				$table->unique(['funder_id', 'locale', 'setting_name'], 'funder_settings_pkey_composite');
+				$table->unique(['funder_id', 'locale', 'setting_name'], 'funder_settings_f_l_s_pkey');
 			});
 
 			# funder_awards
@@ -58,7 +58,7 @@ class FundingSchemaMigration extends Migration {
 				$table->longText('setting_value')->nullable();
 				$table->string('setting_type', 6)->comment('(bool|int|float|string|object)');
 				$table->index(['funder_award_id'], 'funder_award_settings_id');
-				$table->unique(['funder_award_id', 'locale', 'setting_name'], 'funder_award_settings_pkey_composite');
+				$table->unique(['funder_award_id', 'locale', 'setting_name'], 'funder_award_settings_f_l_s_pkey');
 			});
 
 		}

--- a/FundingSchemaMigration.inc.php
+++ b/FundingSchemaMigration.inc.php
@@ -39,7 +39,7 @@ class FundingSchemaMigration extends Migration {
 				$table->longText('setting_value')->nullable();
 				$table->string('setting_type', 6)->comment('(bool|int|float|string|object)');
 				$table->index(['funder_id'], 'funder_settings_id');
-				$table->unique(['funder_id', 'locale', 'setting_name'], 'funder_settings_pkey');
+				$table->unique(['funder_id', 'locale', 'setting_name'], 'funder_settings_pkey_composite');
 			});
 
 			# funder_awards
@@ -58,7 +58,7 @@ class FundingSchemaMigration extends Migration {
 				$table->longText('setting_value')->nullable();
 				$table->string('setting_type', 6)->comment('(bool|int|float|string|object)');
 				$table->index(['funder_award_id'], 'funder_award_settings_id');
-				$table->unique(['funder_award_id', 'locale', 'setting_name'], 'funder_award_settings_pkey');
+				$table->unique(['funder_award_id', 'locale', 'setting_name'], 'funder_award_settings_pkey_composite');
 			});
 
 		}

--- a/schema.xml
+++ b/schema.xml
@@ -60,13 +60,13 @@
 		<index name="funder_settings_id">
 			<col>funder_id</col>
 		</index>
-		<index name="funder_settings_pkey">
+		<index name="funder_settings_pkey_composite">
 			<col>funder_id</col>
 			<col>locale</col>
 			<col>setting_name</col>
 			<UNIQUE />
 		</index>
-	</table>	
+	</table>
 
 	<!--
 	 *
@@ -112,7 +112,7 @@
 		<index name="funder_award_settings_id">
 			<col>funder_award_id</col>
 		</index>
-		<index name="funder_award_settings_pkey">
+		<index name="funder_award_settings_pkey_composite">
 			<col>funder_award_id</col>
 			<col>locale</col>
 			<col>setting_name</col>

--- a/schema.xml
+++ b/schema.xml
@@ -60,7 +60,7 @@
 		<index name="funder_settings_id">
 			<col>funder_id</col>
 		</index>
-		<index name="funder_settings_pkey_composite">
+		<index name="funder_settings_f_l_s_pkey">
 			<col>funder_id</col>
 			<col>locale</col>
 			<col>setting_name</col>
@@ -112,7 +112,7 @@
 		<index name="funder_award_settings_id">
 			<col>funder_award_id</col>
 		</index>
-		<index name="funder_award_settings_pkey_composite">
+		<index name="funder_award_settings_f_l_s_pkey">
 			<col>funder_award_id</col>
 			<col>locale</col>
 			<col>setting_name</col>


### PR DESCRIPTION
@ajnyga Postgres databases create a constraint with the name [TABLE_NAME]_pkey which clashed with the one specified in the migration. 

By renaming the unique key that the migration specifies, we avoid the error `Duplicate table: 7 ERROR:  relation "funder_settings_pkey" already exists (SQL: alter table "funder_settings" add constraint "funder_settings_pkey" unique ("funder_id", "locale", "setting_name"))`. In `[stable-3_3_0](https://github.com/ajnyga/funding/tree/stable-3_3_0)` 

The `Capsule` class was used to do the migrations which seems to handle this and perform the migration in a way that works with Mysql and Postgres. It seems that using the `Schema` class as we are now doesn't work in the same way. We need this to be compatible with Mysql and Postgres. 

https://github.com/ajnyga/funding/issues/52

Please let me know about this I'm happy to help out more

