### PR TITLE
Remove deprecated BC code

### DIFF
--- a/FundingPlugin.php
+++ b/FundingPlugin.php
@@ -653,7 +653,3 @@ class FundingPlugin extends GenericPlugin {
         return parent::manage($args, $request);
     }
 }
-
-if (!PKP_STRICT_MODE) {
-    class_alias('\APP\plugins\generic\funding\FundingPlugin', '\FundingPlugin');
-}

--- a/controllers/grid/FunderGridHandler.php
+++ b/controllers/grid/FunderGridHandler.php
@@ -313,7 +313,3 @@ class FunderGridHandler extends GridHandler {
     }
 
 }
-
-if (!PKP_STRICT_MODE) {
-    class_alias('\APP\plugins\generic\funding\controllers\grid\FunderGridHandler', '\FunderGridHandler');
-}

--- a/controllers/grid/form/FunderForm.php
+++ b/controllers/grid/form/FunderForm.php
@@ -39,7 +39,7 @@ class FunderForm extends Form {
     var $plugin;
 
     /** A mapping of funder DOIs to RORs for funders that support grant ID validation */
-    const array AWARD_FUNDERS = [
+    const AWARD_FUNDERS = [
         'doi.org/10.13039/501100002341' => '05k73zm37', // Research Council of Finland
         'doi.org/10.13039/501100001665' => '00rbzpz17', // French National Research Agency
         'doi.org/10.13039/501100000923' => '05mmh0f86', // Australian Research Council


### PR DESCRIPTION
Since https://github.com/pkp/pkp-lib/issues/11583, the old `define` method of setting strict mode has been changed; at the same time, we've removed a lot of old backwards compatibility support that was deprecated as of OJS 3.4 with the addition of standard classloading. This change should be merged to `main` for OJS 3.6.